### PR TITLE
プレイヤー死亡時のカメラシェイクテスト実装

### DIFF
--- a/Assets/Scripts/Game/Camera/CameraManager.cs
+++ b/Assets/Scripts/Game/Camera/CameraManager.cs
@@ -73,13 +73,6 @@ namespace Play
             //カメラの状態チェック
             CamCheck();
 
-            //TODO　カメラ振動テスト
-            //if (Input.GetMouseButtonDown(0))
-            //{
-            //    //振動
-            //    Debug.Log("カメラ揺らし");
-            //    GetComponent<Play.CameraShake>().ShakeCamera();
-            //}
         }
 
         //遅れて呼び出し（演出の動作の安定性のため）
@@ -220,6 +213,12 @@ namespace Play
         public Cinemachine.CinemachineVirtualCamera GetCullentVCam()
         {
             return _currentCam.GetComponent<Cinemachine.CinemachineVirtualCamera>();
+        }
+
+        public void ShakeCamera()
+        {
+            //カメラ揺らし
+            GetComponent<Play.CameraShake>().ShakeCamera();
         }
     }
 }

--- a/Assets/Scripts/Game/ElementObject/Enemy/PlayerDestroyer.cs
+++ b/Assets/Scripts/Game/ElementObject/Enemy/PlayerDestroyer.cs
@@ -23,6 +23,8 @@ namespace Play.Enemy
             {
                 //プレイヤー死亡処理
                 InGameManager.Instance.StageOver();
+                //カメラシェイク
+                CamMan.GetComponent<CameraManager>().ShakeCamera();
                 //カメラの切り替え
                 CamMan.GetComponent<CameraManager>().MainCameraChange();
 
@@ -37,6 +39,8 @@ namespace Play.Enemy
             {
                 //プレイヤー死亡処理
                 InGameManager.Instance.StageOver();
+                //カメラシェイク
+                CamMan.GetComponent<CameraManager>().ShakeCamera();
                 //カメラの切り替え
                 CamMan.GetComponent<CameraManager>().MainCameraChange();
 


### PR DESCRIPTION
あくまで仮実装
現在はプレイヤーデストロイヤーにてプレイヤー死亡を判定とかいう危険極まりない仕様なので、
他の作業が落ち着いたらプレイヤー死亡周りを見直します。
