### PR TITLE
2度ターゲットの部分修正　Selectorのターゲット表示　細かい修正

### DIFF
--- a/Assets/Prefabs/Game/Object/Enemy.prefab
+++ b/Assets/Prefabs/Game/Object/Enemy.prefab
@@ -22,7 +22,6 @@ GameObject:
   - component: {fileID: 114697729547784942}
   - component: {fileID: 114341245269835074}
   - component: {fileID: 114755572862633682}
-  - component: {fileID: 114754034423396456}
   m_Layer: 0
   m_Name: EnemyElement
   m_TagString: Element
@@ -71,7 +70,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1226374070059844}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -6.5, y: 0.5, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4559477479850780}
@@ -185,25 +184,6 @@ MonoBehaviour:
   _overwritePosList: []
   _speed: 0
   _returnPosition: {x: 0, y: 0, z: 0}
---- !u!114 &114754034423396456
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1141800042515396}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8f80f39e18a722144bc74025249e1f80, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _speed: 0
-  _moveAmount: 1
-  _requiredTime: 3
-  _reversFlag: 0
-  _basePos: {x: 0, y: 0, z: 0}
-  _UpEndPos: {x: 0, y: 0, z: 0}
-  _DownEndPos: {x: 0, y: 0, z: 0}
-  _moveCount: 0
 --- !u!114 &114755572862633682
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Game/Object/Object.prefab
+++ b/Assets/Prefabs/Game/Object/Object.prefab
@@ -38,7 +38,6 @@ GameObject:
   m_Component:
   - component: {fileID: 4481667893767550}
   - component: {fileID: 114107422137317586}
-  - component: {fileID: 114794399861745894}
   m_Layer: 0
   m_Name: ObjectElement
   m_TagString: Element
@@ -84,7 +83,7 @@ Rigidbody2D:
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0
-  m_Mass: 1
+  m_Mass: 100
   m_LinearDrag: 0
   m_AngularDrag: 0.05
   m_GravityScale: 0
@@ -92,7 +91,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!61 &61257137719976572
 BoxCollider2D:
   m_ObjectHideFlags: 1
@@ -134,25 +133,6 @@ MonoBehaviour:
   _overwritePosList: []
   _speed: 0
   _returnPosition: {x: 0, y: 0, z: 0}
---- !u!114 &114794399861745894
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1794738536429786}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8f80f39e18a722144bc74025249e1f80, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _speed: 0
-  _moveAmount: 3
-  _requiredTime: 3
-  _reversFlag: 0
-  _basePos: {x: 0, y: 0, z: 0}
-  _UpEndPos: {x: 0, y: 0, z: 0}
-  _DownEndPos: {x: 0, y: 0, z: 0}
-  _moveCount: 0
 --- !u!212 &212160824459515170
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/Assets/Resources/Stage/TestGrid.prefab
+++ b/Assets/Resources/Stage/TestGrid.prefab
@@ -45,7 +45,7 @@ GameObject:
   - component: {fileID: 114143523640405648}
   m_Layer: 9
   m_Name: Enemy
-  m_TagString: Element
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -226,7 +226,7 @@ GameObject:
   - component: {fileID: 114041956671855272}
   m_Layer: 9
   m_Name: Enemy
-  m_TagString: Element
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -321,7 +321,7 @@ GameObject:
   - component: {fileID: 114955243330391546}
   m_Layer: 9
   m_Name: Enemy
-  m_TagString: Element
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -410,7 +410,7 @@ GameObject:
   - component: {fileID: 114231982820192500}
   m_Layer: 9
   m_Name: Enemy
-  m_TagString: Element
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -472,7 +472,7 @@ GameObject:
   - component: {fileID: 114001985766727612}
   m_Layer: 9
   m_Name: Enemy
-  m_TagString: Element
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -493,7 +493,7 @@ GameObject:
   - component: {fileID: 114049649243483614}
   m_Layer: 9
   m_Name: Enemy
-  m_TagString: Element
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -514,7 +514,7 @@ GameObject:
   - component: {fileID: 114386054760303044}
   m_Layer: 9
   m_Name: Enemy
-  m_TagString: Element
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -592,7 +592,7 @@ GameObject:
   - component: {fileID: 114251925265896548}
   m_Layer: 9
   m_Name: Enemy
-  m_TagString: Element
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -613,7 +613,7 @@ GameObject:
   - component: {fileID: 114640774451922226}
   m_Layer: 9
   m_Name: Enemy
-  m_TagString: Element
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -744,7 +744,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1180695927322336}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 1.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4552654535425448}
@@ -2594,6 +2594,7 @@ MonoBehaviour:
   _elementText: {fileID: 114226643485333420, guid: 546392ba5ab9045488d4cf8c5c867df5,
     type: 2}
   _textList: []
+  _target: {fileID: 1928845370931122, guid: b9f75b0b906d0b54182d9bc7e8c8d965, type: 2}
 --- !u!114 &114298020964573598
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -288,6 +288,11 @@ Prefab:
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114138490012617604, guid: c15c10ff3282bcf4992d7f7c2781f15f,
+        type: 2}
+      propertyPath: m_Lens.OrthographicSize
+      value: 6.6
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: c15c10ff3282bcf4992d7f7c2781f15f, type: 2}
   m_IsPrefabParent: 0


### PR DESCRIPTION
今回は古いMoveObjectを使用する形にします。
現状弾が向いている方向に飛ばないのでそこの部分の修正をお願いします。
その際prefabは触らずSceneのオブジェクトの値をそのまま操作する形でお願いします。